### PR TITLE
環境設定から日本語になるように設定し、削除機能を追加

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -28,6 +28,12 @@ class TasksController < ApplicationController
     redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
   end
 
+  def destroy
+    task = Task.find(params[:id])
+    task.destroy
+    redirect_to tasks_url, notice: "タスク「#{task.name}」を削除しました。"
+  end
+
   private
 
   def task_params

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,7 +9,7 @@ html
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body
     .app-title.navbar.nevber-expand-md.nevbar-light.bg-light 
-      .navbar-brand Tasllist 
+      .navbar-brand Tasklist 
     .container
       -if flash.notice.present?
         .alert.alert-success= flash.notice

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -11,7 +11,8 @@ table.table.table-hover
     tbody
       - @tasks.each do |task|
         tr 
-          td= link_to task.name, task_path(task)
+          td= link_to task.name, task
           td= task.created_at
           td
             = link_to '編集', edit_task_path(task), class: 'btn btn-primary mr-3'
+            = link_to '削除', task, method: :delete, data: {confirm: "タスク「#{task.name}」を削除します。よろしいですか？"}, class: 'btn btn-danger'

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -18,3 +18,4 @@ table.table.table-hover
       td= @task.created_at
 
 = link_to '編集', edit_task_path, class: 'btn btn-primary mr-3'
+= link_to '削除', @task, method: :delete, data: { confirm: "タスク「#{@task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,15 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+    models:
+      task: タスク
+    attributes:
+      task:
+        id: ID
+        name: 名称
+        description: 詳しい説明
+        created_at: 登録日時
+        updated_at: 更新日時
   date:
     abbr_day_names:
     - 日


### PR DESCRIPTION
## 概要
環境設定から日本語になるように設定し、削除機能を追加

## 実装内容

日本語設定のja.ymlで

    models:
      task: タスク
    attributes:
      task:
        id: ID
        name: 名称
        description: 詳しい説明
        created_at: 登録日時
        updated_at: 更新日時

した。

タスクコントローラーにデストロイアクションの中身を書いて
削除ボタンをインデックスと詳細ページに追記した。